### PR TITLE
Add support for embedded iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Bergen Triathlon website
+
 Official website for the Bergen Triathlon.
 
-Frontend is written in Svelte with content being served from a ContentFul backend, currently at https://app.contentful.com/spaces/wi3d49ltoppx
+Frontend is written in Svelte with content being served from a ContentFul backend, currently at https://app.contentful.com/spaces/{space-id}
 
 The content is being fetched using the Contentful [GraphQL Content API](https://www.contentful.com/developers/docs/references/graphql/)
 
@@ -10,14 +11,14 @@ The content is being fetched using the Contentful [GraphQL Content API](https://
 - [Node.js LTS](https://nodejs.org/en/)
 
 1. Add a file with name `.env` to add contentful tokens. Find the access token under `Settings` -> `API Keys` in contentful dashboard.
+
 ```
 VITE_CONTENTFUL_DELIVERY_API_ACCESS_TOKEN=Fetch-Token-From-Contentful-backend
-VITE_CONTENTFUL_SPACE_ID=wi3d49ltoppx
+VITE_CONTENTFUL_SPACE_ID={space-id}
 ```
 
 2. Run `npm install`
 3. Run `npm run dev` to run the development server
-
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,23 @@
-# create-svelte
+# Bergen Triathlon website
+Official website for the Bergen Triathlon.
 
-Everything you need to build a Svelte project, powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte);
+Frontend is written in Svelte with content being served from a ContentFul backend, currently at https://app.contentful.com/spaces/wi3d49ltoppx
 
-## Creating a project
-
-If you're seeing this, you've probably already done this step. Congrats!
-
-```bash
-# create a new project in the current directory
-npm init svelte@next
-
-# create a new project in my-app
-npm init svelte@next my-app
-```
-
-> Note: the `@next` is temporary
+The content is being fetched using the Contentful [GraphQL Content API](https://www.contentful.com/developers/docs/references/graphql/)
 
 ## Developing
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+- [Node.js LTS](https://nodejs.org/en/)
 
-```bash
-npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
+1. Add a file with name `.env` to add contentful tokens. Find the access token under `Settings` -> `API Keys` in contentful dashboard.
 ```
+VITE_CONTENTFUL_DELIVERY_API_ACCESS_TOKEN=Fetch-Token-From-Contentful-backend
+VITE_CONTENTFUL_SPACE_ID=wi3d49ltoppx
+```
+
+2. Run `npm install`
+3. Run `npm run dev` to run the development server
+
 
 ## Building
 

--- a/src/lib/contentful/types/Article.ts
+++ b/src/lib/contentful/types/Article.ts
@@ -1,16 +1,48 @@
+import type { Document } from "@contentful/rich-text-types";
+
 export type Article = {
 	slug: string;
 	title: string;
 	ingress: string;
-	body?: {
-		json: any;
+	body: {
+		json: Document;
+		links: ArticleLinks;
 	};
-	articleHeroImage: {
+	articleHeroImage?: {
 		title: string;
 		url: string;
-	};
+	} | null;
 	author: {
 		name: string;
 	};
 	date: string;
 };
+
+export type ArticleLinks = {
+	assets: {
+		block: any[];
+	};
+	entries: {
+		inline: any[];
+		block: EntryBlock[];
+	}
+}
+
+export type EntryBlock = IFrameEntry | {
+	sys: {
+		id: string;
+	};
+	__typename: string;
+	[key: string]: any;
+};
+
+export type IFrameEntry = {
+	sys: {
+		id: string;
+	};
+	__typename: "IFrame";
+	title: string;
+	url: string;
+	width: string;
+	height: string;
+}

--- a/src/lib/news.svelte
+++ b/src/lib/news.svelte
@@ -9,10 +9,10 @@
 <div class="mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8 px-6">
 	{#each articles as article}
 		<ArticleLink
-			imageAltText={article.articleHeroImage.title}
+			imageAltText={article.articleHeroImage?.title}
 			url={`/news/${article.slug}`}
 			date={format(parseISO(article.date), 'MMM d, yy', { locale: nb })}
-			imageSrc={article.articleHeroImage.url}
+			imageSrc={article.articleHeroImage?.url}
 			title={article.title}
 			ingress={article.ingress}
 		/>

--- a/src/routes/contentful/articles/[slug].json.ts
+++ b/src/routes/contentful/articles/[slug].json.ts
@@ -5,34 +5,57 @@ import graphQLClient from '$lib/contentful/client';
 export const get = async ({ params }): Promise<EndpointOutput<any>> => {
 	const query = gql`
 		query GetArticleBySlug {
-			articleCollection(where: {slug: "${params.slug}"}, limit: 1){
-				items {
-					title
-					ingress
-					body {
-						json
-						links {
-							assets {
-								block {
-									sys {
-										id
-									}
-									url
-									title
-									width
-									height
-									description
-								}
-							}
+			articleCollection(where: {slug: "${params.slug}"}, limit: 1) {
+			items {
+				title
+				ingress
+				body {
+				json
+				links {
+					assets {
+					block {
+						sys {
+						id
 						}
-						
+						url
+						title
+						width
+						height
+						description
 					}
-					date
-					articleHeroImage {
-					  url
-					  title
 					}
-  				} 
+					entries {
+					inline {
+						sys {
+						id
+						}
+						__typename
+						... on Article {
+						title
+						slug
+						}
+					}
+					block {
+						sys {
+						id
+						}
+						__typename
+						... on IFrame {
+						title
+						url
+						width
+						height
+						}
+					}
+					}
+				}
+				}
+				date
+				articleHeroImage {
+				url
+				title
+				}
+			}
 			}
 		}
 	`;

--- a/src/routes/contentful/articles/[slug].json.ts
+++ b/src/routes/contentful/articles/[slug].json.ts
@@ -10,52 +10,52 @@ export const get = async ({ params }): Promise<EndpointOutput<any>> => {
 					title
 					ingress
 					body {
-					json
-					links {
+						json
+						links {
 						assets {
-						block {
+							block {
 							sys {
-							id
+								id
+							}
+							url
+							title
+							width
+							height
+							description
+							}
 						}
+						entries {
+							inline {
+							sys {
+								id
+							}
+							__typename
+							... on Article {
+								title
+								slug
+							}
+							}
+							block {
+							sys {
+								id
+							}
+							__typename
+							... on IFrame {
+								title
+								url
+								width
+								height
+							}
+							}
+						}
+						}
+					}
+					date
+					articleHeroImage {
 						url
 						title
-						width
-						height
-						description
-					}
-					}
-					entries {
-					inline {
-						sys {
-						id
-						}
-						__typename
-						... on Article {
-						title
-						slug
-						}
-					}
-					block {
-						sys {
-						id
-						}
-						__typename
-						... on IFrame {
-						title
-						url
-						width
-						height
-						}
-					}
 					}
 				}
-				}
-				date
-				articleHeroImage {
-				url
-				title
-				}
-			}
 			}
 		}
 	`;

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,5 +1,5 @@
 <script context="module" lang="ts">
-    import {HomePage} from '$lib/contentful/types/HomePage';
+    import type {HomePage} from '$lib/contentful/types/HomePage';
 
     export async function load({fetch}): Promise<any> {
         const [homePageRes, articlesRes, menuRes] = await Promise.all([

--- a/src/routes/news/[slug].svelte
+++ b/src/routes/news/[slug].svelte
@@ -1,116 +1,113 @@
 <script context="module" lang="ts">
-    export async function load({page, fetch}): Promise<any> {
-        const [articleRes, articlesRes, menuRes] = await Promise.all([
-            fetch(`/contentful/articles/${page.params.slug}.json`),
-            fetch(`/contentful/articles.json`),
-            fetch('/contentful/menu.json')
-        ]);
+	export async function load({ page, fetch }): Promise<any> {
+		const [articleRes, articlesRes, menuRes] = await Promise.all([
+			fetch(`/contentful/articles/${page.params.slug}.json`),
+			fetch(`/contentful/articles.json`),
+			fetch('/contentful/menu.json')
+		]);
 
-        if (articlesRes.ok) {
-            const [article, articles, menuItems] = await Promise.all([articleRes.json(), articlesRes.json(), menuRes.json()]);
-            return {props: {menuItems, article, articles}};
-        }
-    }
+		if (articlesRes.ok) {
+			const [article, articles, menuItems] = await Promise.all([
+				articleRes.json(),
+				articlesRes.json(),
+				menuRes.json()
+			]);
+			return { props: { menuItems, article, articles } };
+		}
+	}
 </script>
 
 <script lang="ts">
-    import {BLOCKS} from '@contentful/rich-text-types';
-    import {documentToHtmlString} from '@contentful/rich-text-html-renderer';
-    import News from '$lib/news.svelte';
-    import Header from '$lib/header.svelte';
-    import HorizontalPageDivider from '$lib/horizontalPageDivider.svelte';
-    import type {MenuItem} from "$lib/contentful/types/MenuItemCollectionResponse";
-    import type { Article, ArticleLinks, EntryBlock, IFrameEntry } from '$lib/contentful/types/Article';
+	import { BLOCKS } from '@contentful/rich-text-types';
+	import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
+	import News from '$lib/news.svelte';
+	import Header from '$lib/header.svelte';
+	import HorizontalPageDivider from '$lib/horizontalPageDivider.svelte';
+	import type { MenuItem } from '$lib/contentful/types/MenuItemCollectionResponse';
+	import type {
+		Article,
+		ArticleLinks,
+		EntryBlock,
+		IFrameEntry
+	} from '$lib/contentful/types/Article';
 
-    export let article: Article;
-    export let articles: Article[];
-    export let menuItems: MenuItem[] = [];
+	export let article: Article;
+	export let articles: Article[];
+	export let menuItems: MenuItem[] = [];
 
-    function renderOptions(links: ArticleLinks) {
-        // create an asset map
-        const assetMap = new Map();
-        // loop through the assets and add them to the map
-        for (const asset of links.assets.block) {
-            assetMap.set(asset.sys.id, asset);
-        }
+	function renderOptions(links: ArticleLinks) {
+		const assetMap = new Map();
+		for (const asset of links.assets.block) {
+			assetMap.set(asset.sys.id, asset);
+		}
 
-        // create an entry map
-        const entryMap = new Map<string, EntryBlock>();
-        // loop through the block linked entries and add them to the map
-        for (const entry of links.entries.block) {
-            entryMap.set(entry.sys.id, entry);
-        }
+		const entryMap = new Map<string, EntryBlock>();
+		for (const entry of links.entries.block) {
+			entryMap.set(entry.sys.id, entry);
+		}
 
-        return {
-            renderNode: {
-                [BLOCKS.PARAGRAPH]: (node, next) => `<p class="mb-6">${next(node.content)}</p>`,
-                [BLOCKS.UL_LIST]: (node, next) => `<ul class="list-disc ml-14">${next(node.content)}</ul>`,
-                [BLOCKS.OL_LIST]: (node, next) => `<ol class="list-decimal ml-14">${next(node.content)}</ol>`,
-                [BLOCKS.LIST_ITEM]: (node, next) => `<li>${next(node.content)}</li>`,
-                [BLOCKS.HEADING_1]: (node, next) => `<h1 class="text-4xl">${next(node.content)}</h1>`,
-                [BLOCKS.HEADING_2]: (node, next) => `<h2 class="text-3xl">${next(node.content)}</h2>`,
-                [BLOCKS.HEADING_3]: (node, next) => `<h3 class="text-2xl">${next(node.content)}</h3>`,
-                [BLOCKS.HEADING_4]: (node, next) => `<h4 class="text-xl">${next(node.content)}</h4>`,
-                [BLOCKS.EMBEDDED_ASSET]: (node, next) => {
-                    const asset = assetMap.get(node.data.target.sys.id);
-                    return `<img src=${asset.url} alt="${asset.title}" />`;
-                },
-                [BLOCKS.EMBEDDED_ENTRY]: (node, next) => {
-                    // https://www.contentful.com/blog/2021/04/14/rendering-linked-assets-entries-in-contentful/
-                    // find the entry in the entryMap by ID
-                    const entry = entryMap.get(node.data.target.sys.id);
+		return {
+			renderNode: {
+				[BLOCKS.PARAGRAPH]: (node, next) => `<p class="mb-6">${next(node.content)}</p>`,
+				[BLOCKS.UL_LIST]: (node, next) => `<ul class="list-disc ml-14">${next(node.content)}</ul>`,
+				[BLOCKS.OL_LIST]: (node, next) =>
+					`<ol class="list-decimal ml-14">${next(node.content)}</ol>`,
+				[BLOCKS.LIST_ITEM]: (node, next) => `<li>${next(node.content)}</li>`,
+				[BLOCKS.HEADING_1]: (node, next) => `<h1 class="text-4xl">${next(node.content)}</h1>`,
+				[BLOCKS.HEADING_2]: (node, next) => `<h2 class="text-3xl">${next(node.content)}</h2>`,
+				[BLOCKS.HEADING_3]: (node, next) => `<h3 class="text-2xl">${next(node.content)}</h3>`,
+				[BLOCKS.HEADING_4]: (node, next) => `<h4 class="text-xl">${next(node.content)}</h4>`,
+				[BLOCKS.EMBEDDED_ASSET]: (node, next) => {
+					const asset = assetMap.get(node.data.target.sys.id);
+					return `<img src=${asset.url} alt="${asset.title}" />`;
+				},
+				[BLOCKS.EMBEDDED_ENTRY]: (node, next) => {
+					// https://www.contentful.com/blog/2021/04/14/rendering-linked-assets-entries-in-contentful/
+					const entry = entryMap.get(node.data.target.sys.id);
 
-                    // render the entries as needed by looking at the __typename 
-                    // referenced in the GraphQL query
-                    if (entry.__typename === "IFrame") {
-                        const iframeElementString = `
+					if (entry.__typename === 'IFrame') {
+						const iframeEntry = entry as IFrameEntry;
+						const iframeElementString = `
                             <iframe
-                                src="${(entry as IFrameEntry).url}"
-                                height="${(entry as IFrameEntry).height}"
-                                width="${(entry as IFrameEntry).width}"
+                                src="${iframeEntry.url}"
+                                height="${iframeEntry.height}"
+                                width="${iframeEntry.width}"
                                 frameBorder="0"
                                 scrolling="no"
-                                title="${(entry as IFrameEntry).title}"
-                            >Det ser ut til den innebygde iframen ikke ble lastet inn, prøv igjen senere eller kontakt sideadministrator.</iframe>
+                                title="${iframeEntry.title}"
+                            ></iframe>
                         `;
-                        return iframeElementString;
-                    } else {
-                        console.debug("Nothing");
-                        return "nothing";
-                    }
-                },
-            }
-        };
-    }
-
+						return iframeElementString;
+					}
+				}
+			}
+		};
+	}
 </script>
 
 <svelte:head>
-    <title>B3</title>
+	<title>B3</title>
 </svelte:head>
 
-<Header menuItems={menuItems} />
+<Header {menuItems} />
 
 <main class="container flex flex-col mx-auto article mt-20 mb-40">
-    <div
-            class="container max-w-screen-md mx-auto px-6 flex flex-col"
-    >
-        <h1 class="text-4xl mb-6">{article.title}</h1>
+	<div class="container max-w-screen-md mx-auto px-6 flex flex-col">
+		<h1 class="text-4xl mb-6">{article.title}</h1>
 
-        <p class="mb-6">{article.ingress}</p>
+		<p class="mb-6">{article.ingress}</p>
 
-        <img
-                class="rounded-xl mb-6 w-full"
-                alt={article.articleHeroImage?.title}
-                src={article.articleHeroImage?.url}
-        />
+		<img
+			class="rounded-xl mb-6 w-full"
+			v-if="article.articleHeroImage"
+			alt={article.articleHeroImage?.title}
+			src={article.articleHeroImage?.url}
+		/>
 
-        {@html documentToHtmlString(article.body.json, renderOptions(article.body.links))}
-    </div>
+		{@html documentToHtmlString(article.body.json, renderOptions(article.body.links))}
+	</div>
 
-    <HorizontalPageDivider>
-        Siste nyheter fra Bergen Triathlon Events
-    </HorizontalPageDivider>
+	<HorizontalPageDivider>Siste nyheter fra Bergen Triathlon Events</HorizontalPageDivider>
 
-    <News {articles}/>
+	<News {articles} />
 </main>


### PR DESCRIPTION
Goal: Add support for embedding IFrame in articles in order to render the interactive map.

Added content model in Contentful for IFrame:
![image](https://user-images.githubusercontent.com/5204006/174398495-9a937b04-9080-4820-80e9-8f7bca036162.png)

To use:
1. Add new content with contentType `IFrame`
![image](https://user-images.githubusercontent.com/5204006/174398759-8c9fc5aa-1146-4b83-a8bc-78ddee956058.png)
2. Edit article and click "Embed" -> "Entry" -> Select an IFrame entry
![image](https://user-images.githubusercontent.com/5204006/174398589-c1a08803-7df0-4631-bee3-4d26812bc4d1.png)


Demo of embedded map:
https://user-images.githubusercontent.com/5204006/174398406-4bbe1d0d-5876-4ab4-a931-1e2175162414.mp4



