### PR TITLE
bugfix: use vimeo video.files instead of video.play

### DIFF
--- a/src/lib/services/vimeo/VimeoVideoService.ts
+++ b/src/lib/services/vimeo/VimeoVideoService.ts
@@ -12,11 +12,11 @@ export class VimeoVideoService implements IVideoMetadataService {
 	}
 
 	async getVideoMetadata(id: number): Promise<VideoMetadata> {
-		const { pictures, play } = await this.client.get<VimeoVideoMetadata>(`/videos/${id}`);
+		const { pictures, play, files } = await this.client.get<VimeoVideoMetadata>(`/videos/${id}`);
 		return {
 			id,
 			poster: pictures?.sizes.find(({ width }) => width === 640)?.link,
-			sources: play?.progressive.map(({ link, type }) => ({ uri: link, type: type }))
+			sources: files.map(({ link, type }) => ({ uri: link, type: type }))
 		};
 	}
 }

--- a/src/lib/services/vimeo/types/VimeoVideoMetadata.ts
+++ b/src/lib/services/vimeo/types/VimeoVideoMetadata.ts
@@ -1,6 +1,7 @@
 export type VimeoVideoMetadata = {
 	pictures: VimeoVideoPictures;
 	play: VimeoVideoPlay;
+	files: VimeoVideoFile[];
 };
 
 type VimeoVideoPlay = {


### PR DESCRIPTION
- Video links from Vimeo are expiring. This PR changes the field from which we're extracting video resources from `play` to `files` as proposed in this [StackOverflow post](https://stackoverflow.com/questions/49797074/get-a-non-expiring-video-file-url-using-vimeo-api).